### PR TITLE
Make pzrun build on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,15 @@ CC=gcc
 
 # Debugging
 # MCFLAGS=--use-grade-subdirs --grade asm_fast.gc.decldebug.stseg
-# CFLAGS=-std=c99 -D_POSIX_C_SOURCE=2 -Wall -Werror -g
+# CFLAGS=-std=c99 -D_POSIX_C_SOURCE=2 -D_C99_SOURCE -Wall -Werror -g
 
 # Plain
 MCFLAGS=--use-grade-subdirs
-CFLAGS=-std=c99 -D_POSIX_C_SOURCE=2 -Wall -Werror
+CFLAGS=-std=c99 -D_POSIX_C_SOURCE=2 -D_C99_SOURCE -Wall -Werror
 
 # Optimisation
 # MCFLAGS=--use-grade-subdirs -O4 --intermodule-optimisation
-# CFLAGS=-std=c99 -D_POSIX_C_SOURCE=2 -Wall -Werror -O3
+# CFLAGS=-std=c99 -D_POSIX_C_SOURCE=2 -D_C99_SOURCE -Wall -Werror -O3
 
 vpath %.m src
 vpath %.c runtime


### PR DESCRIPTION
OS X ships with an stdio.h file that requires a certain macro to be defined before you can use `snprintf`, and for some reason it wasn't defined.