### PR TITLE
[plasmac] Prettify core pretty printer output

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,3 +1,4 @@
 *.diff
 *.out
 *.pz
+*.plasma-dump*


### PR DESCRIPTION
 - Consistently indent with two spaces.
 - Numbered expressions are correctly indented according to the string length
   of the number.
 - Multiline tuple elements are printed prettily.
 - A space is printed before the open curly of a function body.

src/core.pretty.m:
	As above.